### PR TITLE
feat: export google objects

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@adobe/helix-shared-string": "^2.1.0",
         "googleapis": "^149.0.0",
+        "googleapis-common": "7.2.0",
         "lru-cache": "^11.0.2"
       },
       "devDependencies": {
@@ -2566,20 +2567,6 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/@smithy/middleware-retry/node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "dev": true,
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
     "node_modules/@smithy/middleware-serde": {
       "version": "3.0.10",
       "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-3.0.10.tgz",
@@ -3329,9 +3316,10 @@
       "dev": true
     },
     "node_modules/bignumber.js": {
-      "version": "9.1.1",
-      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.1.1.tgz",
-      "integrity": "sha512-pHm4LsMJ6lzgNGVfZHjMoO8sdoRhOzOH4MLmY65Jg70bpxCKu5iOHNJyfF6OyvYw7t8Fpf35RuzUyqnQsj8Vig==",
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.0.tgz",
+      "integrity": "sha512-EM7aMFTXbptt/wZdMlBv2t8IViwQL+h6SLHosp8Yf0dqJMTnY6iL32opnAB6kAdL0SZPuvcAzFr31o0c/R3/RA==",
+      "license": "MIT",
       "engines": {
         "node": "*"
       }
@@ -5108,25 +5096,29 @@
       }
     },
     "node_modules/gaxios": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-6.1.0.tgz",
-      "integrity": "sha512-EIHuesZxNyIkUGcTQKQPMICyOpDD/bi+LJIJx+NLsSGmnS7N+xCLRX5bi4e9yAu9AlSZdVq+qlyWWVuTh/483w==",
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-6.7.1.tgz",
+      "integrity": "sha512-LDODD4TMYx7XXdpwxAVRAIAuB0bzv0s+ywFonY46k126qzQHT9ygyoa9tncmOiQmmDrik65UYsEkv3lbfqQ3yQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "extend": "^3.0.2",
         "https-proxy-agent": "^7.0.1",
         "is-stream": "^2.0.0",
-        "node-fetch": "^2.6.9"
+        "node-fetch": "^2.6.9",
+        "uuid": "^9.0.1"
       },
       "engines": {
         "node": ">=14"
       }
     },
     "node_modules/gcp-metadata": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-6.0.0.tgz",
-      "integrity": "sha512-Ozxyi23/1Ar51wjUT2RDklK+3HxqDr8TLBNK8rBBFQ7T85iIGnXnVusauj06QyqCXRFZig8LZC+TUddWbndlpQ==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-6.1.1.tgz",
+      "integrity": "sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "gaxios": "^6.0.0",
+        "gaxios": "^6.1.1",
+        "google-logging-utils": "^0.0.2",
         "json-bigint": "^1.0.0"
       },
       "engines": {
@@ -5356,31 +5348,29 @@
       }
     },
     "node_modules/google-auth-library": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.0.0.tgz",
-      "integrity": "sha512-IQGjgQoVUAfOk6khqTVMLvWx26R+yPw9uLyb1MNyMQpdKiKt0Fd9sp4NWoINjyGHR8S3iw12hMTYK7O8J07c6Q==",
+      "version": "9.15.1",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.15.1.tgz",
+      "integrity": "sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng==",
+      "license": "Apache-2.0",
       "dependencies": {
         "base64-js": "^1.3.0",
         "ecdsa-sig-formatter": "^1.0.11",
-        "gaxios": "^6.0.0",
-        "gcp-metadata": "^6.0.0",
+        "gaxios": "^6.1.1",
+        "gcp-metadata": "^6.1.0",
         "gtoken": "^7.0.0",
-        "jws": "^4.0.0",
-        "lru-cache": "^6.0.0"
+        "jws": "^4.0.0"
       },
       "engines": {
         "node": ">=14"
       }
     },
-    "node_modules/google-auth-library/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
+    "node_modules/google-logging-utils": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-0.0.2.tgz",
+      "integrity": "sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ==",
+      "license": "Apache-2.0",
       "engines": {
-        "node": ">=10"
+        "node": ">=14"
       }
     },
     "node_modules/googleapis": {
@@ -5397,27 +5387,20 @@
       }
     },
     "node_modules/googleapis-common": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/googleapis-common/-/googleapis-common-7.0.0.tgz",
-      "integrity": "sha512-58iSybJPQZ8XZNMpjrklICefuOuyJ0lMxfKmBqmaC0/xGT4SiOs4BE60LAOOGtBURy1n8fHa2X2YUNFEWWbXyQ==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/googleapis-common/-/googleapis-common-7.2.0.tgz",
+      "integrity": "sha512-/fhDZEJZvOV3X5jmD+fKxMqma5q2Q9nZNSF3kn1F18tpxmA86BcTxAGBQdM0N89Z3bEaIs+HVznSmFJEAmMTjA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "extend": "^3.0.2",
         "gaxios": "^6.0.3",
-        "google-auth-library": "^9.0.0",
+        "google-auth-library": "^9.7.0",
         "qs": "^6.7.0",
         "url-template": "^2.0.8",
         "uuid": "^9.0.0"
       },
       "engines": {
         "node": ">=14.0.0"
-      }
-    },
-    "node_modules/googleapis-common/node_modules/uuid": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
-      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
-      "bin": {
-        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/gopd": {
@@ -6266,6 +6249,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
       "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "license": "MIT",
       "dependencies": {
         "bignumber.js": "^9.0.0"
       }
@@ -12312,6 +12296,19 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true
     },
+    "node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/v8-to-istanbul": {
       "version": "9.1.0",
       "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.1.0.tgz",
@@ -12542,7 +12539,8 @@
     "node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
     },
     "node_modules/yaml": {
       "version": "2.8.0",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   "dependencies": {
     "@adobe/helix-shared-string": "^2.1.0",
     "googleapis": "^149.0.0",
+    "googleapis-common": "7.2.0",
     "lru-cache": "^11.0.2"
   },
   "devDependencies": {

--- a/src/GoogleClient.js
+++ b/src/GoogleClient.js
@@ -10,12 +10,23 @@
  * governing permissions and limitations under the License.
  */
 import { LRUCache } from 'lru-cache';
-import { google } from 'googleapis';
+import { AuthPlus } from 'googleapis-common';
+import googleDocs from 'googleapis/build/src/apis/docs/v1.js';
+import googleDrive from 'googleapis/build/src/apis/drive/v3.js';
+import googleSheets from 'googleapis/build/src/apis/sheets/v4.js';
+
 import {
   editDistance, sanitizeName, splitByExtension,
 } from '@adobe/helix-shared-string';
 import { GoogleTokenCache } from './GoogleTokenCache.js';
 import { StatusCodeError } from './StatusCodeError.js';
+
+const google = {
+  auth: new AuthPlus(),
+  docs: (opts) => new googleDocs.docs_v1.Docs(opts),
+  drive: (opts) => new googleDrive.drive_v3.Drive(opts),
+  sheets: (opts) => new googleSheets.sheets_v4.Sheets(opts),
+};
 
 let lru = new LRUCache({ max: 1000, ttl: 60000 });
 

--- a/src/GoogleClient.js
+++ b/src/GoogleClient.js
@@ -10,23 +10,12 @@
  * governing permissions and limitations under the License.
  */
 import { LRUCache } from 'lru-cache';
-import { AuthPlus } from 'googleapis-common';
-import googleDocs from 'googleapis/build/src/apis/docs/v1.js';
-import googleDrive from 'googleapis/build/src/apis/drive/v3.js';
-import googleSheets from 'googleapis/build/src/apis/sheets/v4.js';
-
 import {
   editDistance, sanitizeName, splitByExtension,
 } from '@adobe/helix-shared-string';
 import { GoogleTokenCache } from './GoogleTokenCache.js';
 import { StatusCodeError } from './StatusCodeError.js';
-
-const google = {
-  auth: new AuthPlus(),
-  docs: (opts) => new googleDocs.docs_v1.Docs(opts),
-  drive: (opts) => new googleDrive.drive_v3.Drive(opts),
-  sheets: (opts) => new googleSheets.sheets_v4.Sheets(opts),
-};
+import { google } from './google.js';
 
 let lru = new LRUCache({ max: 1000, ttl: 60000 });
 

--- a/src/google.js
+++ b/src/google.js
@@ -10,11 +10,19 @@
  * governing permissions and limitations under the License.
  */
 import { AuthPlus } from 'googleapis-common';
-import googleDocs from 'googleapis/build/src/apis/docs/index.js';
-import googleDrive from 'googleapis/build/src/apis/drive/index.js';
-import googleSheets from 'googleapis/build/src/apis/sheets/index.js';
-import googleOAuth2 from 'googleapis/build/src/apis/oauth2/index.js';
+import docs from 'googleapis/build/src/apis/docs/index.js';
+import drive from 'googleapis/build/src/apis/drive/index.js';
+import sheets from 'googleapis/build/src/apis/sheets/index.js';
+import oauth2 from 'googleapis/build/src/apis/oauth2/index.js';
 
+/**
+ * Given an API object exposing a `VERSIONS` property, return the appropriate instance
+ * of that API based on the `version` property in options.
+ *
+ * @param {any} api API object exposing a `VERSIONS` property.
+ * @param {object} opts options
+ * @returns API instance
+ */
 function apiVersion(api, opts) {
   const ctor = api.VERSIONS[opts.version];
   // eslint-disable-next-line no-param-reassign
@@ -25,10 +33,10 @@ function apiVersion(api, opts) {
 
 const google = {
   auth: new AuthPlus(),
-  oauth2: (opts) => apiVersion(googleOAuth2, opts),
-  docs: (opts) => apiVersion(googleDocs, opts),
-  drive: (opts) => apiVersion(googleDrive, opts),
-  sheets: (opts) => apiVersion(googleSheets, opts),
+  oauth2: (opts) => apiVersion(oauth2, opts),
+  docs: (opts) => apiVersion(docs, opts),
+  drive: (opts) => apiVersion(drive, opts),
+  sheets: (opts) => apiVersion(sheets, opts),
 };
 
 export { google };

--- a/src/google.js
+++ b/src/google.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Adobe. All rights reserved.
+ * Copyright 2025 Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License. You may obtain a copy
  * of the License at http://www.apache.org/licenses/LICENSE-2.0
@@ -9,6 +9,16 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-export { GoogleClient } from './GoogleClient.js';
-export { GoogleTokenCache } from './GoogleTokenCache.js';
-export { google } from './google.js';
+import { AuthPlus } from 'googleapis-common';
+import googleDocs from 'googleapis/build/src/apis/docs/v1.js';
+import googleDrive from 'googleapis/build/src/apis/drive/v3.js';
+import googleSheets from 'googleapis/build/src/apis/sheets/v4.js';
+
+const google = {
+  auth: new AuthPlus(),
+  docs: (opts) => new googleDocs.docs_v1.Docs(opts),
+  drive: (opts) => new googleDrive.drive_v3.Drive(opts),
+  sheets: (opts) => new googleSheets.sheets_v4.Sheets(opts),
+};
+
+export { google };

--- a/src/google.js
+++ b/src/google.js
@@ -14,11 +14,17 @@ import googleDocs from 'googleapis/build/src/apis/docs/v1.js';
 import googleDrive from 'googleapis/build/src/apis/drive/v3.js';
 import googleSheets from 'googleapis/build/src/apis/sheets/v4.js';
 
+function stripVersion(opts) {
+  // eslint-disable-next-line no-param-reassign
+  delete opts.version;
+  return opts;
+}
+
 const google = {
   auth: new AuthPlus(),
-  docs: (opts) => new googleDocs.docs_v1.Docs(opts),
-  drive: (opts) => new googleDrive.drive_v3.Drive(opts),
-  sheets: (opts) => new googleSheets.sheets_v4.Sheets(opts),
+  docs: (opts) => new googleDocs.docs_v1.Docs(stripVersion(opts)),
+  drive: (opts) => new googleDrive.drive_v3.Drive(stripVersion(opts)),
+  sheets: (opts) => new googleSheets.sheets_v4.Sheets(stripVersion(opts)),
 };
 
 export { google };

--- a/src/google.js
+++ b/src/google.js
@@ -10,23 +10,25 @@
  * governing permissions and limitations under the License.
  */
 import { AuthPlus } from 'googleapis-common';
-import googleDocs from 'googleapis/build/src/apis/docs/v1.js';
-import googleDrive from 'googleapis/build/src/apis/drive/v3.js';
-import googleSheets from 'googleapis/build/src/apis/sheets/v4.js';
-import googleOAuth2 from 'googleapis/build/src/apis/oauth2/v2.js';
+import googleDocs from 'googleapis/build/src/apis/docs/index.js';
+import googleDrive from 'googleapis/build/src/apis/drive/index.js';
+import googleSheets from 'googleapis/build/src/apis/sheets/index.js';
+import googleOAuth2 from 'googleapis/build/src/apis/oauth2/index.js';
 
-function stripVersion(opts) {
+function apiVersion(api, opts) {
+  const ctor = api.VERSIONS[opts.version];
   // eslint-disable-next-line no-param-reassign
   delete opts.version;
-  return opts;
+  // eslint-disable-next-line new-cap
+  return new ctor(opts);
 }
 
 const google = {
   auth: new AuthPlus(),
-  oauth2: (opts) => new googleOAuth2.oauth2_v2.Oauth2(stripVersion(opts)),
-  docs: (opts) => new googleDocs.docs_v1.Docs(stripVersion(opts)),
-  drive: (opts) => new googleDrive.drive_v3.Drive(stripVersion(opts)),
-  sheets: (opts) => new googleSheets.sheets_v4.Sheets(stripVersion(opts)),
+  oauth2: (opts) => apiVersion(googleOAuth2, opts),
+  docs: (opts) => apiVersion(googleDocs, opts),
+  drive: (opts) => apiVersion(googleDrive, opts),
+  sheets: (opts) => apiVersion(googleSheets, opts),
 };
 
 export { google };

--- a/src/google.js
+++ b/src/google.js
@@ -13,6 +13,7 @@ import { AuthPlus } from 'googleapis-common';
 import googleDocs from 'googleapis/build/src/apis/docs/v1.js';
 import googleDrive from 'googleapis/build/src/apis/drive/v3.js';
 import googleSheets from 'googleapis/build/src/apis/sheets/v4.js';
+import googleOAuth2 from 'googleapis/build/src/apis/oauth2/v2.js';
 
 function stripVersion(opts) {
   // eslint-disable-next-line no-param-reassign
@@ -22,6 +23,7 @@ function stripVersion(opts) {
 
 const google = {
   auth: new AuthPlus(),
+  oauth2: (opts) => new googleOAuth2.oauth2_v2.Oauth2(stripVersion(opts)),
   docs: (opts) => new googleDocs.docs_v1.Docs(stripVersion(opts)),
   drive: (opts) => new googleDrive.drive_v3.Drive(stripVersion(opts)),
   sheets: (opts) => new googleSheets.sheets_v4.Sheets(stripVersion(opts)),

--- a/src/index.js
+++ b/src/index.js
@@ -9,5 +9,19 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
+import { AuthPlus } from 'googleapis-common';
+import googleDocs from 'googleapis/build/src/apis/docs/v1.js';
+import googleDrive from 'googleapis/build/src/apis/drive/v3.js';
+import googleSheets from 'googleapis/build/src/apis/sheets/v4.js';
+
 export { GoogleClient } from './GoogleClient.js';
 export { GoogleTokenCache } from './GoogleTokenCache.js';
+
+const google = {
+  auth: new AuthPlus(),
+  docs: (opts) => new googleDocs.docs_v1.Docs(opts),
+  drive: (opts) => new googleDrive.drive_v3.Drive(opts),
+  sheets: (opts) => new googleSheets.sheets_v4.Sheets(opts),
+};
+
+export { google };


### PR DESCRIPTION
the library `googleapis` exports every API supported (over 500), and all of them get added to a service bundle, increasing its size by over 20MB.

instead, we just export the APIs we need in this library.