### PR TITLE
fix: arguments to OAuth2 should be passed as object

### DIFF
--- a/src/GoogleClient.js
+++ b/src/GoogleClient.js
@@ -114,11 +114,11 @@ export class GoogleClient {
       auth = new google.auth.OAuth2();
       auth.setCredentials({ access_token: `${opts.token}` });
     } else {
-      auth = new google.auth.OAuth2(
-        opts.clientId,
-        opts.clientSecret,
-        opts.redirectUri,
-      );
+      auth = new google.auth.OAuth2({
+        clientId: opts.clientId,
+        clientSecret: opts.clientSecret,
+        redirectUri: opts.redirectUri,
+      });
     }
     Object.assign(this, {
       log: opts.log,

--- a/test/google-client.test.js
+++ b/test/google-client.test.js
@@ -59,6 +59,20 @@ describe('GoogleClient tests', () => {
     assert.strictEqual(GoogleClient.id2Url('gdrive:foobar'), 'gdrive:foobar');
   });
 
+  describe('generic tests', () => {
+    it('create GoogleClient with just redirect URI', async () => {
+      const redirectUri = 'http://localhost:3000/';
+      const client = await new GoogleClient({ redirectUri }).init();
+      const { auth } = client;
+
+      assert.strictEqual(auth.redirectUri, redirectUri);
+      const url = await client.generateAuthUrl();
+      const { searchParams } = new URL(url);
+      assert.strictEqual(searchParams.get('redirect_uri'), redirectUri);
+      assert.strictEqual(searchParams.get('client_id'), '');
+    });
+  });
+
   describe('getItemsFromPath tests', () => {
     it('getItemsFromPath returns item hierarchy', async () => {
       nock.loginGoogle(4);


### PR DESCRIPTION
background `google-auth-library` >= 10 stops interpreting arguments passed directly if the first (`clientId`) is already empty
